### PR TITLE
Handle start/stop events

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -5,7 +5,7 @@ import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { version } from "./rise-playlist-version.js";
 import { Schedule } from "./schedule.js";
 
-class RisePlaylistItem extends RiseElement {
+export class RisePlaylistItem extends RiseElement {
 
   static get template() {
     return html`
@@ -35,6 +35,21 @@ class RisePlaylistItem extends RiseElement {
       }
     }
   }
+
+  play() {
+    this._sendEventToChildren("rise-playlist-play");
+  }
+
+  stop() {
+    this._sendEventToChildren("rise-playlist-stop");
+  }
+
+  _sendEventToChildren(eventName) {
+    for (let i = 0; i < this.children.length; i++) {
+      this.children[i].dispatchEvent(new Event(eventName));
+    }
+  }
+
 }
 
 customElements.define("rise-playlist-item", RisePlaylistItem);
@@ -60,6 +75,13 @@ export default class RisePlaylist extends RiseElement {
     super();
     this.schedule = new Schedule();
     this._setVersion( version );
+  }
+
+  ready() {
+    super.ready();
+
+    this.addEventListener( "rise-presentation-play", () => this.schedule.start());
+    this.addEventListener( "rise-presentation-stop", () => this.schedule.stop());
   }
 
   _removeAllItems() {
@@ -130,7 +152,6 @@ export default class RisePlaylist extends RiseElement {
       });
 
       this.schedule.items = this.schedule.items.filter(item => !info.removedNodes.includes(item.element));
-      this.schedule.start();
     });
   }
 

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -5,10 +5,12 @@ class TransitionHandler {
   transition(from, to) {
     if (from && from.style) {
       from.style.display = "none";
+      from.stop();
     }
 
     if (to && to.style) {
       to.style.display = "block";
+      to.play();
     }
   }
 
@@ -23,11 +25,19 @@ class Schedule {
   }
 
   start() {
-    this.stop();
+    this.reset();
     this.play();
   }
 
   stop() {
+    this.reset();
+    this.items.forEach(item => {
+      item.element.style.display = "none";
+      item.element.stop();
+    });
+  }
+
+  reset() {
     clearTimeout(this.itemDurationTimer);
     this.playingItem = null;
   }

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -10,6 +10,7 @@
     <script src="../node_modules/@polymer/test-fixture/test-fixture.js"></script>
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/sinon/pkg/sinon.js"></script>
     <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
 
     <script type="text/javascript">
@@ -71,14 +72,19 @@
     </test-fixture>
 
     <script type="module">
+      import { RisePlaylistItem } from '../src/rise-playlist.js';
+
       suite('rise-playlist', () => {
 
         suite('static items attribute', () => {
           let element = null;
+          const sandbox = sinon.createSandbox();
 
           setup(() => {
             element = fixture('StaticValueTestFixture');
           });
+
+          teardown(() => sandbox.restore());
 
           test('setting "items" attribute on the element works', (done) => {
             flush(() => {
@@ -138,6 +144,21 @@
             });
           });
 
+          test('should start schedule on "rise-presentation-play" event', () => {
+            sandbox.stub(element.schedule, "start");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element.schedule.start.called, true);
+          });
+
+          test('should stop schedule on "rise-presentation-stop" event', () => {
+            sandbox.stub(element.schedule, "stop");
+
+            element.dispatchEvent(new Event("rise-presentation-stop"));
+
+            assert.equal(element.schedule.stop.called, true);
+          });
         });
 
         suite('nested html items', () => {
@@ -197,6 +218,33 @@
 
               done();
             });
+          });
+        });
+
+        suite('rise-playlist-item', () => {
+
+          test('play should send "rise-playlist-play" event to children', (done) => {
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            child.addEventListener("rise-playlist-play", () => {
+              done();
+            });
+
+            item.play();
+          });
+
+          test('stop should send "rise-playlist-stop" event to children', (done) => {
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            child.addEventListener("rise-playlist-stop", () => {
+              done();
+            });
+
+            item.stop();
           });
         });
 

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -16,6 +16,7 @@
   <body>
 
     <script type="module">
+      import { RisePlaylistItem } from '../src/rise-playlist.js';
       import { Schedule, TransitionHandler } from '../src/schedule.js';
 
       suite('schedule', () => {
@@ -65,16 +66,16 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: document.createElement('rise-playlist-item')
+            element: new RisePlaylistItem()
           };
 
-          const secontItem = {
+          const secondItem = {
             duration: 12,
             playUntilDone: false,
-            element: document.createElement('rise-playlist-item')
+            element: new RisePlaylistItem()
           };
 
-          schedule.items = [firstItem, secontItem];
+          schedule.items = [firstItem, secondItem];
 
           schedule.start();
 
@@ -82,12 +83,91 @@
 
           clock.tick((firstItem.duration + 1) * 1000);
 
-          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secontItem.element), true);
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), true);
 
-          clock.tick((secontItem.duration + 1) * 1000);
+          clock.tick((secondItem.duration + 1) * 1000);
 
-          assert.equal(transitionHandler.transition.calledWith(secontItem.element, firstItem.element), true);
+          assert.equal(transitionHandler.transition.calledWith(secondItem.element, firstItem.element), true);
+        });
 
+        test('should stop rise-playlist-item elements when playlist stops', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: new RisePlaylistItem()
+          };
+          sandbox.stub(firstItem.element, "stop");
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: new RisePlaylistItem()
+          };
+          sandbox.stub(secondItem.element, "stop");
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.stop();
+
+          assert.equal(firstItem.element.stop.called, true);
+          assert.equal(secondItem.element.stop.called, true);
+        });
+
+      });
+
+      suite('transitions', () => {
+        const sandbox = sinon.createSandbox();
+
+        let transitionHandler = null;
+
+        setup(() => {
+          transitionHandler = new TransitionHandler();
+        });
+
+        teardown(() => sandbox.restore());
+
+        test('should stop previous item and start the next', () => {
+
+          const previous = {
+            style: {
+              display: {}
+            },
+            stop: sandbox.spy()
+          };
+
+          const next = {
+            style: {
+              display: {}
+            },
+            play: sandbox.spy()
+          };
+
+          transitionHandler.transition(previous, next);
+
+          assert.equal(previous.stop.called, true);
+          assert.equal(next.play.called, true);
+        });
+
+
+        test('should hide previous item and show the next', () => {
+          const previous = {
+            style: {
+              display: {}
+            },
+            stop: sandbox.spy()
+          };
+
+          const next = {
+            style: {
+              display: {}
+            },
+            play: sandbox.spy()
+          };
+
+          transitionHandler.transition(previous, next);
+
+          assert.equal(previous.style.display, "none");
+          assert.equal(next.style.display, "block");
         });
 
       });


### PR DESCRIPTION
## Description
- Start/stop rise-playlist schedule on "rise-presentation-play" and "rise-presentation-stop" events in host template
- Send "rise-playlist-play" and "rise-playlist-stop" events to rise-playlist-item on schedule transition

## Motivation and Context
-  Embedded templates schedule should start when the host template start on "rise-presentation-play" event. 
- Playlist items should receive events on schedule transition so that rise-embedded-template elements can send "rise-presentation-play" and "rise-presentation-stop" events to the embedded templates

## How Has This Been Tested?
Tested locally with Chrome OS Player. Unit tests added.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
