### PR TITLE
Start schedule when items attribute is set

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -152,6 +152,7 @@ export default class RisePlaylist extends RiseElement {
       });
 
       this.schedule.items = this.schedule.items.filter(item => !info.removedNodes.includes(item.element));
+      this.schedule.start();
     });
   }
 


### PR DESCRIPTION
## Description
The items attribute is set with data from attributes-data.json after "rise-presentation-play". We need to start the schedule again when this happens. 

## Motivation and Context
Restart schedule when items change

## How Has This Been Tested?
Tested locally on Chrome Player.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
