### PR TITLE
Handle playlist item PUD

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -39,7 +39,20 @@ export class RisePlaylistItem extends RiseElement {
   constructor() {
     super();
     this._done = false;
-    this._setDone = () => this._done = true;
+    this._isPlaying = false;
+  }
+
+  ready() {
+    super.ready();
+    if (this.firstElementChild && this.playUntilDone) {
+      this.firstElementChild.addEventListener("report-done", () => this._setDone());
+    }
+  }
+
+  _setDone() {
+    if (this._isPlaying) {
+      this._done = true;
+    }
   }
 
   isDone() {
@@ -52,16 +65,12 @@ export class RisePlaylistItem extends RiseElement {
 
   play() {
     this._sendEventToChild("rise-playlist-play");
-    if (this.firstElementChild && this.playUntilDone) {
-      this.firstElementChild.addEventListener("report-done", this._setDone);
-    }
+    this._isPlaying = true;
   }
 
   stop() {
     this._sendEventToChild("rise-playlist-stop");
-    if (this.firstElementChild && this.playUntilDone) {
-      this.firstElementChild.removeEventListener("report-done", this._setDone);
-    }
+    this._isPlaying = false;
   }
 
   _sendEventToChild(eventName) {

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -36,18 +36,37 @@ export class RisePlaylistItem extends RiseElement {
     }
   }
 
+  constructor() {
+    super();
+    this._done = false;
+    this._setDone = () => this._done = true;
+  }
+
+  isDone() {
+    return this._done;
+  }
+
+  resetDone() {
+    this._done = false;
+  }
+
   play() {
-    this._sendEventToChildren("rise-playlist-play");
+    this._sendEventToChild("rise-playlist-play");
+    if (this.firstElementChild && this.playUntilDone) {
+      this.firstElementChild.addEventListener("report-done", this._setDone);
+    }
   }
 
   stop() {
-    this._sendEventToChildren("rise-playlist-stop");
+    this._sendEventToChild("rise-playlist-stop");
+    if (this.firstElementChild && this.playUntilDone) {
+      this.firstElementChild.removeEventListener("report-done", this._setDone);
+    }
   }
 
-  _sendEventToChildren(eventName) {
-    // RisePlaylistItem should only have a single child, but it sends the event for all children just to be safe
-    for (let i = 0; i < this.children.length; i++) {
-      this.children[i].dispatchEvent(new Event(eventName));
+  _sendEventToChild(eventName) {
+    if (this.firstElementChild) {
+      this.firstElementChild.dispatchEvent(new Event(eventName));
     }
   }
 

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -54,6 +54,15 @@ class Schedule {
 
     clearTimeout(this.itemDurationTimer);
 
+    if (this.playingItem && this.playingItem.playUntilDone) {
+      if (this.playingItem.element.isDone()) {
+        this.playingItem.element.resetDone();
+      } else {
+        this.itemDurationTimer = setTimeout(() => this.play(), 1000);
+        return;
+      }
+    }
+
     let nextItem = this.playingItems.shift();
     this.playingItems.push(nextItem);
 
@@ -70,7 +79,7 @@ class Schedule {
       this.doneListener();
     }
 
-    this.itemDurationTimer= setTimeout(() => this.play(), nextItem.duration * 1000);
+    this.itemDurationTimer = setTimeout(() => this.play(), nextItem.playUntilDone ? 1000 : nextItem.duration * 1000);
   }
 }
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -267,6 +267,41 @@
 
             item.stop();
           });
+
+          test('should set done when child sends "report-done"', () => {
+            const item = new RisePlaylistItem();
+            item.playUntilDone = true;
+
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            item.play();
+
+            assert.equal(item.isDone(), false);
+
+            child.dispatchEvent(new Event("report-done"));
+
+            assert.equal(item.isDone(), true);
+          });
+
+          test('should not set done when child sends "report-done" when item is stopped', () => {
+            const item = new RisePlaylistItem();
+            item.playUntilDone = true;
+
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            item.play();
+
+            assert.equal(item.isDone(), false);
+
+            item.stop();
+
+            child.dispatchEvent(new Event("report-done"));
+
+            assert.equal(item.isDone(), false);
+          });
+
         });
 
       });

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -275,6 +275,8 @@
             const child = document.createElement('rise-embedded-template');
             item.appendChild(child);
 
+            item.ready();
+
             item.play();
 
             assert.equal(item.isDone(), false);
@@ -290,6 +292,8 @@
 
             const child = document.createElement('rise-embedded-template');
             item.appendChild(child);
+
+            item.ready();
 
             item.play();
 

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -114,6 +114,75 @@
           assert.equal(schedule.doneListener.calledTwice, true);
         });
 
+        test('should play multiple items until done', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: new RisePlaylistItem()
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: true,
+            element: new RisePlaylistItem()
+          };
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.start();
+
+          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true);
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), true);
+
+          clock.tick((secondItem.duration + 1) * 1000);
+
+          assert.equal(transitionHandler.transition.calledWith(secondItem.element, firstItem.element), false);
+
+          secondItem.element._setDone();
+
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(secondItem.element, firstItem.element), true);
+        });
+
+        test('should play single play until done item', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: true,
+            element: new RisePlaylistItem()
+          };
+
+          schedule.doneListener = sandbox.spy();
+
+          schedule.items = [firstItem];
+
+          schedule.start();
+
+          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true);
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          firstItem.element._setDone();
+
+          clock.tick(1000);
+
+          assert.equal(schedule.doneListener.calledOnce, true);
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          assert.equal(schedule.doneListener.calledOnce, true);
+
+          firstItem.element._setDone();
+
+          clock.tick(1000);
+
+          assert.equal(schedule.doneListener.calledTwice, true);
+
+        });
+
         test('should call done listener when it finishes playing multiple items', () => {
           const firstItem = {
             duration: 10,

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -30,7 +30,7 @@
           clock = sinon.useFakeTimers();
 
           transitionHandler = new TransitionHandler();
-          sandbox.stub(transitionHandler, "transition");
+          sandbox.stub(transitionHandler, "transition").callThrough();
 
           schedule = new Schedule(transitionHandler);
         });


### PR DESCRIPTION
## Description
- Listen to "report-done" from playlist item child and set item as done
- Schedule should check every second until item is done

## Motivation and Context
Items marked play-until-done work as expected

## How Has This Been Tested?
Tested locally on Chrome player 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
