### PR TITLE
Remove call to hide playlist item elements when schedule stops

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -183,10 +183,7 @@ class Schedule {
 
   stop() {
     this.reset();
-    this.playingItems.forEach(item => {
-      item.element.style.display = "none";
-      item.element.stop();
-    });
+    this.playingItems.forEach(item => item.element.stop());
   }
 
   reset() {


### PR DESCRIPTION
## Description
- This is not needed anymore after the transition classes where added

## Motivation and Context
It was causing an issue where the playlist disappears after the first schedule transition when there is multiple items in the display schedule

## How Has This Been Tested?
Tested locally

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
