### PR TITLE
Handle ready event

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -43,13 +43,22 @@ export class RisePlaylistItem extends RiseElement {
     super();
     this._done = false;
     this._isPlaying = false;
+    this._isReady = false;
   }
 
   ready() {
     super.ready();
-    if (this.firstElementChild && this.playUntilDone) {
-      this.firstElementChild.addEventListener("report-done", () => this._setDone());
+    if (this.firstElementChild) {
+      if (this.playUntilDone) {
+        this.firstElementChild.addEventListener("report-done", () => this._setDone());
+      }
+
+      this.firstElementChild.addEventListener("rise-components-ready", () => this._isReady = true);
     }
+  }
+
+  isNotReady() {
+    return !this._isReady;
   }
 
   _setDone() {

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -279,6 +279,11 @@ class Schedule {
 
     this.playingItems.push(nextItem);
 
+    if (nextItem.element.isNotReady()) {
+      this.itemDurationTimer = setTimeout(() => this.play(), 1000);
+      return;
+    }
+
     let previousItem = this.playingItem;
 
     this.playingItem = nextItem;

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -306,6 +306,22 @@
             assert.equal(item.isDone(), false);
           });
 
+          test('should set ready when child sends "rise-components-ready"', () => {
+            const item = new RisePlaylistItem();
+            item.playUntilDone = true;
+
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.equal(item.isNotReady(), true);
+
+            child.dispatchEvent(new Event('rise-components-ready'));
+
+            assert.equal(item.isNotReady(), false);
+          });
+
         });
 
       });

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -27,6 +27,12 @@
         let schedule = null;
         let transitionHandler = null;
 
+        function createRisePlaylistItem(ready = true) {
+          const element = new RisePlaylistItem();
+          element._isReady = ready;
+          return element;
+        }
+
         setup(() => {
           clock = sinon.useFakeTimers();
 
@@ -53,7 +59,7 @@
           const item = {
             duration: 10,
             playUntilDone: false,
-            element: document.createElement('rise-playlist-item')
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [item];
@@ -67,13 +73,13 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           const secondItem = {
             duration: 12,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [firstItem, secondItem];
@@ -95,7 +101,7 @@
           const item = {
             duration: 10,
             playUntilDone: false,
-            element: document.createElement('rise-playlist-item')
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [item];
@@ -119,13 +125,13 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           const secondItem = {
             duration: 12,
             playUntilDone: true,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [firstItem, secondItem];
@@ -153,7 +159,7 @@
           const firstItem = {
             duration: 10,
             playUntilDone: true,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           schedule.doneListener = sandbox.spy();
@@ -188,13 +194,13 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           const secondItem = {
             duration: 12,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [firstItem, secondItem];
@@ -222,14 +228,14 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
           sandbox.stub(firstItem.element, "stop");
 
           const secondItem = {
             duration: 12,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
           sandbox.stub(secondItem.element, "stop");
 
@@ -245,13 +251,13 @@
           const firstItem = {
             duration: 10,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           const secondItem = {
             duration: 12,
             playUntilDone: false,
-            element: new RisePlaylistItem()
+            element: createRisePlaylistItem()
           };
 
           schedule.items = [firstItem, secondItem];
@@ -263,6 +269,51 @@
 
           assert.equal(schedule.items[0], firstItem);
           assert.equal(schedule.items[1], secondItem);
+        });
+
+        test('should skip items that are not ready', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: createRisePlaylistItem()
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          const thirdItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem()
+          };
+
+          schedule.items = [firstItem, secondItem, thirdItem];
+
+          schedule.start();
+
+          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true);
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), false);
+
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, thirdItem.element), true);
+
+          clock.tick((thirdItem.duration + 1) * 1000);
+
+          assert.equal(transitionHandler.transition.calledWith(thirdItem.element, firstItem.element), true);
+
+          secondItem.element._isReady = true;
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), true);
+
         });
 
       });


### PR DESCRIPTION
## Description
- Handle rise-components-ready event in RisePlaylistItem and set a flag indicating if item is ready or not
- Skip items that are not ready when playing the schedule

## Motivation and Context
- Avoid getting stuck showing an empty state when the template is not ready

## How Has This Been Tested?
- Tested locally with Chrome player
- Unit tests added

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
