### PR TITLE
Set width, height and display styles in rise-playlist

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -103,6 +103,9 @@ export default class RisePlaylist extends RiseElement {
         :host {
           position: relative;
           overflow: hidden;
+          display: block;
+          height: 100%;
+          width: 100%;
         }
       </style>
       <slot></slot>


### PR DESCRIPTION
## Description
Set width, height and display styles in rise-playlist
## Motivation and Context
Make it fit the container element. This was brought up by creative when validating the component.

## How Has This Been Tested?
Tested locally. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
