### PR TITLE
Render preview state

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -9,6 +9,7 @@
   <script type="module">
     // Basic noop script that helps forcing shared bundle file creation.
     import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+    import "@polymer/polymer/lib/elements/dom-if.js";
   </script>
   <script src="../src/rise-playlist.js" type="module"></script>
 </head>

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -1,5 +1,6 @@
 import { html } from "@polymer/polymer";
 import { FlattenedNodesObserver } from "@polymer/polymer/lib/utils/flattened-nodes-observer.js";
+import "@polymer/polymer/lib/elements/dom-if.js";
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { version } from "./rise-playlist-version.js";
 import { Schedule } from "./schedule.js";
@@ -107,7 +108,44 @@ export default class RisePlaylist extends RiseElement {
           height: 100%;
           width: 100%;
         }
+        #previewPlaceholder {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          flex-direction: column;
+          text-align: center;
+          position: absolute;
+          left: 0;
+          top: 0;
+          width: 100%;
+          height: 100%;
+          background-color: #F2F2F2;
+        }
+        #previewPlaceholder svg {
+          height: 120px;
+          width: 100%;
+        }
+        #previewPlaceholder h1 {
+          color: #020620;
+          font-size: 48px;
+          text-transform: initial;
+          font-family: Helvetica, Arial, sans-serif;
+        }
       </style>
+      <template is="dom-if" if="{{isPreview()}}">
+      <div id="previewPlaceholder">
+        <svg viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+          <g id="1.-Atoms" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+              <g id="Desktop/Icons" transform="translate(-423.000000, -1232.000000)" fill="#020620" fill-rule="nonzero">
+                  <g id="icon-embedded-templates" transform="translate(423.000000, 1232.000000)">
+                      <path d="M55,0 C57.6887547,0 59.8818181,2.12230671 59.9953805,4.78311038 L60,5 L60,55 C60,57.6887547 57.8776933,59.8818181 55.2168896,59.9953805 L55,60 L5,60 C2.3112453,60 0.118181885,57.8776933 0.00461951385,55.2168896 L0,55 L0,5 C0,2.3112453 2.12230671,0.118181885 4.78311038,0.00461951385 L5,0 L55,0 Z M53.75,32.5 L33.75,32.5 C33.0596441,32.5 32.5,33.0596441 32.5,33.75 L32.5,33.75 L32.5,53.75 C32.5,54.4403559 33.0596441,55 33.75,55 L33.75,55 L53.75,55 C54.4403559,55 55,54.4403559 55,53.75 L55,53.75 L55,33.75 C55,33.0596441 54.4403559,32.5 53.75,32.5 L53.75,32.5 Z" id="Shape"></path>
+                  </g>
+              </g>
+          </g>
+        </svg>
+        <h1>Embedded Template</h1>
+      </div>
+      </template>
       <slot></slot>
     `;
   }
@@ -128,11 +166,21 @@ export default class RisePlaylist extends RiseElement {
     this._setVersion( version );
   }
 
+  isPreview() {
+    return RisePlayerConfiguration && RisePlayerConfiguration.isPreview();
+  }
+
   ready() {
     super.ready();
 
-    this.addEventListener( "rise-presentation-play", () => this.schedule.start());
+    this.addEventListener( "rise-presentation-play", () => this._startSchedule());
     this.addEventListener( "rise-presentation-stop", () => this.schedule.stop());
+  }
+
+  _startSchedule() {
+    if (!this.isPreview()) {
+      this.schedule.start();
+    }
   }
 
   _onScheduleDone() {
@@ -201,7 +249,7 @@ export default class RisePlaylist extends RiseElement {
       });
 
       this.schedule.items = this.schedule.items.filter(item => !info.removedNodes.includes(item.element));
-      this.schedule.start();
+      this._startSchedule();
     });
   }
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -15,7 +15,8 @@
 
     <script type="text/javascript">
       RisePlayerConfiguration = {
-        isConfigured: () => true
+        isConfigured: () => true,
+        isPreview: () => false
       };
     </script>
 
@@ -151,6 +152,15 @@
             element.dispatchEvent(new Event("rise-presentation-play"));
 
             assert.equal(element.schedule.start.called, true);
+          });
+
+          test('should not start schedule on "rise-presentation-play" event when in preview mode', () => {
+            sandbox.stub(RisePlayerConfiguration, "isPreview").returns(true);
+            sandbox.stub(element.schedule, "start");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element.schedule.start.called, false);
           });
 
           test('should stop schedule on "rise-presentation-stop" event', () => {


### PR DESCRIPTION
## Description
Render preview state

## Motivation and Context
Rendering the embedded templates on preview either in the template editor or when the template is running as standalone is difficult because the component depends on events that are triggered by Viewer (rise-presentation-play, rise-presentation-stop, rise-components-ready and template-done). While these events can be simulated in preview mode, the embedded templates won't render properly because they depend on data from player. 

In order to keep it consistent, the component will render an overlay similar to what rise-video does when running in preview state.

## How Has This Been Tested?
Tested locally. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
