### PR TITLE
Fix play until done for empty playlist

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -249,7 +249,7 @@ export default class RisePlaylist extends RiseElement {
       });
 
       this.schedule.items = this.schedule.items.filter(item => !info.removedNodes.includes(item.element));
-      this._startSchedule();
+      // this._startSchedule();
     });
   }
 

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -161,6 +161,7 @@ export default class RisePlaylist extends RiseElement {
 
   constructor() {
     super();
+    this._isPlaying = false;
     this.schedule = new Schedule();
     this.schedule.doneListener = () => this._onScheduleDone();
     this._setVersion( version );
@@ -174,14 +175,20 @@ export default class RisePlaylist extends RiseElement {
     super.ready();
 
     this.addEventListener( "rise-presentation-play", () => this._startSchedule());
-    this.addEventListener( "rise-presentation-stop", () => this.schedule.stop());
+    this.addEventListener( "rise-presentation-stop", () => this._stopSchedule());
   }
 
   _startSchedule() {
     if (!this.isPreview()) {
+      this._isPlaying = true;
       this.schedule.start();
     }
   }
+
+  _stopSchedule() {
+    this._isPlaying = false;
+    this.schedule.stop();
+}
 
   _onScheduleDone() {
     if (this.hasAttribute("play-until-done")) {
@@ -249,7 +256,10 @@ export default class RisePlaylist extends RiseElement {
       });
 
       this.schedule.items = this.schedule.items.filter(item => !info.removedNodes.includes(item.element));
-      // this._startSchedule();
+
+      if (this._isPlaying) {
+        this._startSchedule();
+      }
     });
   }
 

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -261,6 +261,7 @@ class Schedule {
 
   play() {
     if (!this.playingItems || this.playingItems.length === 0) {
+      setTimeout(() => this.doneListener(), 1000);
       return;
     }
 


### PR DESCRIPTION
## Description
- Fix play until done for empty playlist.
- Start/restart schedule only if content is playing.

## Motivation and Context
- There was a problem that the "done" even was never triggered when playlist if empty.
- There was a problem that the content was starting playing before component received the "rise-presentation-play" event. This was messing up the PUD functionality.

## How Has This Been Tested?
Tested on display. Confirmed that PUD is working correctly in all cases. There are 2 groups of test cases:

First group:
1) Schedule has only one presentation
2) Schedule has more that one presentation

Second group:
A) Embedded Template presentation starts with empty playlist.
B) Embedded Template presentation starts with non-empty playlist.

The following scenarios were tested within combination each group ( 4 groups in total - 1A, 1B, 2A, 2B ):
- PUD works without any changes to the content (presentation or schedule)
- while presentation is playing - add item with specific duration
- while presentation is playing - add item with PUD
- while presentation is playing - add one item with specific duration and one item with PUD
- while presentation is playing - remove all items

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
