### PR TITLE
Add ID to the dynamically created elements

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -209,9 +209,16 @@ export default class RisePlaylist extends RiseElement {
       return item.element && item.element.tagName && item.element.tagName !== "";
     });
 
+    let itemIndex = 0;
+
     validItems.map(item => {
+      itemIndex++;
+
+      let playListItemId = this.id + "_" + itemIndex;
 
       const playListItem = document.createElement("rise-playlist-item");
+
+      playListItem.setAttribute("id", playListItemId);
 
       if (item["duration"]) {
         playListItem.setAttribute("duration", item["duration"]);
@@ -226,6 +233,8 @@ export default class RisePlaylist extends RiseElement {
       }
 
       const element = document.createElement(item.element.tagName);
+
+      element.setAttribute("id", playListItemId + "_" + item.element.tagName);
 
       Object.entries(item.element.attributes).forEach(([key, value]) => {
         element.setAttribute(key, value);

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -26,7 +26,7 @@
 
     <test-fixture id="StaticValueTestFixture">
       <template>
-        <rise-playlist items='[{
+        <rise-playlist id='playlist1' items='[{
           "duration": 1,
           "transition-type": "fadeIn",
           "element": {
@@ -142,6 +142,32 @@
             flush(() => {
               assert.equal(element.items.length, 4);
               assert.equal(element.schedule.items.length, 1);
+              done();
+            });
+          });
+
+          test('<play-list-item> and <embedded-template> elements have ID(s)', (done) => {
+
+            const item = {
+              "duration": 2,
+              "transition-type": "fadeIn",
+              "element": {
+                "tagName": "rise-embedded-template",
+                "attributes": {
+                  "template-id": "a429c126-598d-4251-9c0e-b49821056608"
+                }
+              }
+            };
+
+            element.items = [item, item];
+
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+              assert.equal(playlistItemElements[0].id, "playlist1_1");
+              assert.equal(playlistItemElements[1].id, "playlist1_2");
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+              assert.equal(embeddedTemplateElement.id, "playlist1_1_rise-embedded-template");
               done();
             });
           });


### PR DESCRIPTION
## Description
Fix `invalid component data` error by adding the "ID" attribute to the dynamically created elements. 
The error was caused by  <rise-playlist-item> component trying to log "start received" even [here](https://github.com/Rise-Vision/rise-common-component/blob/master/src/rise-element.js#L113), but failing the "id" check [here](https://github.com/Rise-Vision/common-template/blob/0f7237010bc5a4dc0313315860494dafacda3939/src/rise-logger.js#L203) and as a result logging a severe error instead.

## Motivation and Context
Fix **severe** error.

## How Has This Been Tested?
Confirmed on local machine in Chrome inspector that error is not logged anymore.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
