### PR TITLE
Add static background for e2e test template

### DIFF
--- a/e2e/rise-playlist.html
+++ b/e2e/rise-playlist.html
@@ -31,6 +31,11 @@
         }
       }
     </script>
+    <style>
+       body {
+         background-color: lightgray;
+       }
+    </style>
   </head>
   <body>
     <rise-playlist></rise-playlist>


### PR DESCRIPTION
## Description
Add static background for e2e test template

## Motivation and Context
Fixes issue where Viewer background could break tests

## How Has This Been Tested?
Validated changes with the other builds.
e2e page has the expected background: http://widgets.risevision.com/beta/e2e/rise-playlist/electron/e2e/rise-playlist.html

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No