### PR TITLE
Playlist improvements

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -84,13 +84,12 @@ export class RisePlaylistItem extends RiseElement {
   }
 
   play() {
+    this._done = false;
     this._sendEventToChild("rise-playlist-play");
     this._isPlaying = true;
   }
 
   stop() {
-    this._done = false;
-
     this._sendEventToChild("rise-playlist-stop");
     this._isPlaying = false;
   }

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -83,16 +83,14 @@ export class RisePlaylistItem extends RiseElement {
     return this._done;
   }
 
-  resetDone() {
-    this._done = false;
-  }
-
   play() {
     this._sendEventToChild("rise-playlist-play");
     this._isPlaying = true;
   }
 
   stop() {
+    this._done = false;
+
     this._sendEventToChild("rise-playlist-stop");
     this._isPlaying = false;
   }

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -45,6 +45,7 @@ export class RisePlaylistItem extends RiseElement {
     this._done = false;
     this._isPlaying = false;
     this._isReady = false;
+    this._isError = false;
   }
 
   ready() {
@@ -55,6 +56,7 @@ export class RisePlaylistItem extends RiseElement {
       }
 
       this.firstElementChild.addEventListener("rise-components-ready", () => this._setReady());
+      this.firstElementChild.addEventListener("rise-components-error", () => this._isError = true);
     }
   }
 
@@ -65,6 +67,10 @@ export class RisePlaylistItem extends RiseElement {
 
   isNotReady() {
     return !this._isReady;
+  }
+
+  isError() {
+    return this._isError;
   }
 
   _setDone() {

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -270,6 +270,16 @@ class Schedule {
 
     clearTimeout(this.itemDurationTimer);
 
+    let allTemplatesReturnedError = this.playingItems.every(item => item.element.isError());
+
+    if (allTemplatesReturnedError) {
+      // this condition occurs when Viewer runs without Player in the Shared Schedules mode
+      // and all embedded temaplates have unsupported compoenent like Video or Financial
+      console.log("All templates faild to load");
+      setTimeout(() => this.doneListener(), 1000);
+      return;
+    }
+
     if (this.playingItem && this.playingItem.playUntilDone &&
       !this.playingItem.element.isDone()) {
         this.itemDurationTimer = setTimeout(() => this.play(), 1000);

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -278,7 +278,7 @@ class Schedule {
 
     if (allTemplatesReturnedError) {
       // this condition occurs when Viewer runs without Player in the Shared Schedules mode
-      // and all embedded temaplates have unsupported compoenent like Video or Financial
+      // and all embedded templates have unsupported components like Video or Financial
       console.log("All templates faild to load");
       setTimeout(() => this._sendDoneEvent(), 1000);
       return;

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -283,7 +283,7 @@ class Schedule {
 
     this.playingItems.push(nextItem);
 
-    if (nextItem.element.isNotReady()) {
+    if (nextItem.element.isNotReady() || nextItem.element.isError()) {
       console.log(`${nextItem.element.id} is not ready`);
       this.itemDurationTimer = setTimeout(() => this.play(), 1000);
       return;

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -240,9 +240,11 @@ class Schedule {
     this.playingItem = null;
     this.firstItem = null;
     this.itemDurationTimer = null;
+    this.startTime = null;
   }
 
   start() {
+    this.startTime = new Date();
     this.reset();
     this.play();
   }
@@ -277,6 +279,15 @@ class Schedule {
       // and all embedded temaplates have unsupported compoenent like Video or Financial
       console.log("All templates faild to load");
       setTimeout(() => this.doneListener(), 1000);
+      return;
+    }
+
+    const PLAYLIST_LOAD_TIMEOUT_MS = 30000;
+    let allTemplatesNotReady = this.playingItems.every(item => item.element.isNotReady());
+
+    if (allTemplatesNotReady && (new Date().getTime() - this.startTime.getTime()) > PLAYLIST_LOAD_TIMEOUT_MS) {
+      console.log("Playlilst timed out");
+      this.doneListener();
       return;
     }
 

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -270,13 +270,10 @@ class Schedule {
 
     clearTimeout(this.itemDurationTimer);
 
-    if (this.playingItem && this.playingItem.playUntilDone) {
-      if (this.playingItem.element.isDone()) {
-        this.playingItem.element.resetDone();
-      } else {
+    if (this.playingItem && this.playingItem.playUntilDone &&
+      !this.playingItem.element.isDone()) {
         this.itemDurationTimer = setTimeout(() => this.play(), 1000);
         return;
-      }
     }
 
     let nextItem = this.playingItems.shift();

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -288,7 +288,7 @@ class Schedule {
     let allTemplatesNotReady = this.playingItems.every(item => item.element.isNotReady());
 
     if (allTemplatesNotReady && (new Date().getTime() - this.startTime.getTime()) > PLAYLIST_LOAD_TIMEOUT_MS) {
-      console.log("Playlilst timed out");
+      console.log("Playlist timed out");
       this._sendDoneEvent();
       return;
     }

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -118,7 +118,7 @@
 
           clock.tick((item.duration + 1) * 1000);
 
-          assert.equal(schedule.doneListener.calledTwice, true);
+          assert.equal(schedule.doneListener.calledOnce, true, "done is called only once at the end of first round");
         });
 
         test('should play multiple items until done', () => {
@@ -168,7 +168,7 @@
 
           schedule.start();
 
-          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true);
+          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true, 'firstItem started playing');
 
           clock.tick((firstItem.duration + 1) * 1000);
 
@@ -176,18 +176,17 @@
 
           clock.tick(1000);
 
-          assert.equal(schedule.doneListener.calledOnce, true);
+          assert.equal(schedule.doneListener.calledOnce, true, 'done is called first time');
 
           clock.tick((firstItem.duration + 1) * 1000);
 
-          assert.equal(schedule.doneListener.calledOnce, true);
+          assert.equal(schedule.doneListener.callCount, 1, 'done is not called when duration is passed for PUD item');
 
           firstItem.element._setDone();
 
           clock.tick(1000);
 
-          assert.equal(schedule.doneListener.calledTwice, true);
-
+          assert.equal(schedule.doneListener.calledOnce, true, 'schedule.doneListener is only called once');
         });
 
         test('should call done listener when it finishes playing multiple items', () => {
@@ -205,23 +204,23 @@
 
           schedule.items = [firstItem, secondItem];
 
-          schedule.doneListener = sandbox.spy();
+          schedule._sendDoneEvent = sandbox.spy();
 
           schedule.start();
 
-          assert.equal(schedule.doneListener.called, false);
+          assert.equal(schedule._sendDoneEvent.called, false);
 
           clock.tick((firstItem.duration + 1) * 1000);
 
-          assert.equal(schedule.doneListener.calledOnce, false);
+          assert.equal(schedule._sendDoneEvent.calledOnce, false);
 
           clock.tick((secondItem.duration + 1) * 1000);
 
-          assert.equal(schedule.doneListener.calledOnce, true);
+          assert.equal(schedule._sendDoneEvent.calledOnce, true);
 
           clock.tick((firstItem.duration + secondItem.duration + 1) * 1000);
 
-          assert.equal(schedule.doneListener.calledTwice, true);
+          assert.equal(schedule._sendDoneEvent.calledTwice, true);
         });
 
         test('should call done listener when it finishes playing playlist and last item is still not ready', () => {

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -306,6 +306,34 @@
           assert.equal(schedule.doneListener.called, true, 'done is called');
         });
 
+        test('should call done listener if all temapltes return error', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          firstItem.element._isError = true;
+          secondItem.element._isError = true;
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.doneListener = sandbox.spy();
+
+          schedule.start();
+
+          // wait 2 seconds because done is called 1 secod after start()
+          clock.tick(2000);
+
+          assert.equal(schedule.doneListener.called, true, 'done is called');
+        });
+
         test('should stop rise-playlist-item elements when playlist stops', () => {
           const firstItem = {
             duration: 10,

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -301,7 +301,11 @@
 
           schedule.start();
 
-          clock.tick(30 * 1000);
+          clock.tick(29 * 1000);
+
+          assert.equal(schedule.doneListener.called, false, 'done is not called');
+
+          clock.tick(2000);
 
           assert.equal(schedule.doneListener.called, true, 'done is called');
         });

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -309,7 +309,7 @@
           assert.equal(schedule.doneListener.called, true, 'done is called');
         });
 
-        test('should call done listener if all temapltes return error', () => {
+        test('should call done listener if all templates return error', () => {
           const firstItem = {
             duration: 10,
             playUntilDone: false,

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -146,7 +146,7 @@
 
           clock.tick((secondItem.duration + 1) * 1000);
 
-          assert.equal(transitionHandler.transition.calledWith(secondItem.element, firstItem.element), false);
+          assert.equal(transitionHandler.transition.calledWith(secondItem.element, firstItem.element), false, 'duration/timer is ignored');
 
           secondItem.element._setDone();
 
@@ -224,6 +224,88 @@
           assert.equal(schedule.doneListener.calledTwice, true);
         });
 
+        test('should call done listener when it finishes playing playlist and last item is still not ready', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: createRisePlaylistItem(true)
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.doneListener = sandbox.spy();
+
+          schedule.start();
+
+          assert.equal(schedule.playingItem, firstItem, 'started playing first item');
+
+          clock.tick((firstItem.duration + 1) * 1000);
+
+          assert.equal(schedule.playingItem, firstItem, 'second item is skipped, back to the first item');
+
+          assert.equal(schedule.doneListener.calledOnce, true, 'done is called');
+        });
+
+        test('should call done listener when it finishes playing playlist and first item is still not ready', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem()
+          };
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.doneListener = sandbox.spy();
+
+          schedule.start();
+
+          assert.equal(schedule.playingItem, null, 'first item is skipped');
+
+          clock.tick(1000);
+
+          assert.equal(schedule.playingItem, secondItem, 'started playing second item');
+
+          clock.tick((secondItem.duration + 1) * 1000);
+
+          assert.equal(schedule.doneListener.calledOnce, true, 'done is called');
+        });
+
+        test('should call done listener after 30 seconds if none of the items are ready', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: false,
+            element: createRisePlaylistItem(false)
+          };
+
+          schedule.items = [firstItem, secondItem];
+
+          schedule.doneListener = sandbox.spy();
+
+          schedule.start();
+
+          clock.tick(30 * 1000);
+
+          assert.equal(schedule.doneListener.called, true, 'done is called');
+        });
+
         test('should stop rise-playlist-item elements when playlist stops', () => {
           const firstItem = {
             duration: 10,
@@ -271,7 +353,7 @@
           assert.equal(schedule.items[1], secondItem);
         });
 
-        test('should skip items that are not ready', () => {
+        test('should skip items that are not ready - non PUD', () => {
           const firstItem = {
             duration: 10,
             playUntilDone: false,
@@ -314,6 +396,53 @@
 
           assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), true);
 
+        });
+
+        test('should skip items that are not ready - PUD', () => {
+          const firstItem = {
+            duration: 10,
+            playUntilDone: true,
+            element: createRisePlaylistItem()
+          };
+
+          const secondItem = {
+            duration: 12,
+            playUntilDone: true,
+            element: createRisePlaylistItem(false)
+          };
+
+          const thirdItem = {
+            duration: 12,
+            playUntilDone: true,
+            element: createRisePlaylistItem()
+          };
+
+          schedule.items = [firstItem, secondItem, thirdItem];
+
+          schedule.start();
+
+          assert.equal(transitionHandler.transition.calledWith(null, firstItem.element), true, 'first item started playing');
+
+          firstItem.element._setDone();
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), false, 'second item is skipped because it\'s not ready');
+
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, thirdItem.element), true, 'third item started playing');
+
+          thirdItem.element._setDone();
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(thirdItem.element, firstItem.element), true, 'back to the first item');
+
+          secondItem.element._isReady = true;
+
+          firstItem.element._setDone();
+          clock.tick(1000);
+
+          assert.equal(transitionHandler.transition.calledWith(firstItem.element, secondItem.element), true, 'second item started playing becuse it\'s ready now');
         });
 
       });


### PR DESCRIPTION
## Description
Fix for use cases when "done" was not sent by playlist. Use cases:
- All items in the playlist return error. This may occur when Viewer runs without Player in the Shared Schedules mode and all embedded templates have unsupported components like Video or Financial. Fixed by adding event listener for "rise-components-error" event sent by [rise-embedded-template](https://github.com/Rise-Vision/rise-embedded-template/blob/de153fdd63838d21c78bf2541ce6206b341815de/src/rise-embedded-template.js#L141).
- All items in the playlist failed to load without error. Fixed by adding 30 seconds timeout.
- First template fails to load i.e. remain in the "not ready" state. Fixed by moving the check for the "done" condition before checking for "not ready" state.

Other improvements:
- If playlist consisted of 3 PUD templates and second template fails to load, then first template would play twice before moving to the third item. The main cause was that item's "done" flag was reset as soon as item stopped playing. Fixed by calling reset only when `play` command for the item is called.
- Playlist was triggering "done" event after end of each cycle instead of just calling it just once at the end of the first cycle. 

## Motivation and Context
- Use cases above are essential for playlist to work correctly in the Shared Schedules mode.

## How Has This Been Tested?
With unit tests and on local machine using Chrome OS player.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
