### PR TITLE
Move "rise-presentation-play" and "rise-presentation-stop” event handlers to RiseElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.6.1"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#stage/add-play-event-handler"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#stage/add-play-event-handler"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.7.1"
   },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -180,16 +180,16 @@ export default class RisePlaylist extends RiseElement {
     return RisePlayerConfiguration && RisePlayerConfiguration.isPreview() && !RisePlayerConfiguration.Helpers.isInViewer();
   }
 
-  ready() {
-    super.ready();
+  _handleRisePresentationPlay() {
+    super._handleRisePresentationPlay();
 
-    this.addEventListener( "rise-presentation-play", () => this._handleRisePresentationPlay());
-    this.addEventListener( "rise-presentation-stop", () => this._stopSchedule());
+    this._startSchedule();
   }
 
-  _handleRisePresentationPlay() {
-    console.log(`playlist received rise-presentation-play. ID=${this.id}`);
-    this._startSchedule();
+  _handleRisePresentationStop() {
+    super._handleRisePresentationStop();
+
+    this._stopSchedule();
   }
 
   _startSchedule() {


### PR DESCRIPTION
## Description
This is part 2 of 2. Part 1 is [here](https://github.com/Rise-Vision/rise-common-component/pull/43).
Move `"rise-presentation-play"` and `"rise-presentation-stop”` event handlers from `rise-playlist-new` to `rise-common-component`. Those events are not specific to the `rise-playlist-new` only and don't belong there.

## Motivation and Context
Motivated by issue https://github.com/Rise-Vision/rise-embedded-template/issues/17. The is an alternative fix for the issue. Registering event handlers before sending `"configured"` to the `common-template` [here](https://github.com/Rise-Vision/rise-common-component/compare/stage/add-play-event-handler?expand=1#diff-984deaa28b4ffc2771d3d888d97b7223R109) guarantees that `"rise-presentation-play"` event won't be missed in case if `common-template` handles `"configured"` synchronously (which was the case before https://github.com/Rise-Vision/common-template/pull/119).

## How Has This Been Tested?
New unit tests are added.
Tested manually on local machine using template with `rise-playlist` component and Charles proxy. Confirmed that `rise-playlist` component receives `"rise-presentation-play"`.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
