### PR TITLE
Fix for issue 28 - reset transition on schedule stop

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -223,10 +223,17 @@ const transitions = {
 class TransitionHandler {
 
   transition(from, to) {
-    const transitionType = to.transitionType;
-    const transition = transitions[transitionType];
+    this.getTransitionObject(to).run(from, to);
+  }
 
-    transition.run(from, to);
+  reset(element) {
+    this.getTransitionObject(element).reset(element);
+  }
+
+  getTransitionObject(element) {
+    const transitionType = element.transitionType;
+
+    return transitions[transitionType];
   }
 
 }
@@ -252,7 +259,10 @@ class Schedule {
 
   stop() {
     this.reset();
-    this.playingItems.forEach(item => item.element.stop());
+    this.playingItems.forEach(item => {
+      this.transitionHandler.reset(item.element);
+      item.element.stop();
+    });
   }
 
   reset() {

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -38,6 +38,7 @@
 
           transitionHandler = new TransitionHandler();
           sandbox.stub(transitionHandler, "transition").callThrough();
+          sandbox.stub(transitionHandler, "reset").callThrough();
 
           schedule = new Schedule(transitionHandler);
         });
@@ -358,6 +359,10 @@
 
           assert.equal(firstItem.element.stop.called, true);
           assert.equal(secondItem.element.stop.called, true);
+
+          //transitions are reset
+          assert.equal(transitionHandler.reset.calledWith(firstItem.element), true);
+          assert.equal(transitionHandler.reset.calledWith(secondItem.element), true);
         });
 
         test('should keep items order when stop/starts', () => {


### PR DESCRIPTION
## Description
Fix for issue #28 - reset transition on schedule stop. The problem occurs when there is more than one presentation in a schedule. The problem was that the playlist did not hide the last embedded presentation when it received the `stop` command from the Viewer. So, when a presentation with the playlist receives `start` command again, the playlist makes the first item visible, but a user cannot see because it's hidden under the last playlist item. The visibility of the item is controlled by Transitions, so the fix simply resets transitions when playlist is stopped.

## Motivation and Context
0 defects

## How Has This Been Tested?
Visually on local machine. Tests are updated.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
