### PR TITLE
Deploy staging to branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,16 +70,6 @@ jobs:
           paths:
             - gcloud
 
-  generate-version:
-    docker: *BUILDIMAGE
-    steps:
-      - run: mkdir version-string
-      - run: echo $(date +%Y.%m.%d.%H.%M) > version-string/version
-      - persist_to_workspace:
-          root: .
-          paths:
-            - version-string
-
   build-e2e-page:
     parameters:
       stage:
@@ -93,7 +83,7 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
       - run: echo build e2e page << parameters.stage >>
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}')
           sed "
             s/__STAGE__/<< parameters.stage >>/;
             s/__VERSION__/$VERSION/;
@@ -117,7 +107,7 @@ jobs:
       - run: cp -r gcloud ~/.config
       - run: npm install rise-common-component
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=$(echo -n $CIRCLE_BRANCH |awk 'BEGIN{FS="/"}{print tolower($NF)}')
           TARGET=$WIDGETS_BASE/staging/components/rise-playlist/$VERSION/
           echo Deploying version $VERSION to rise-playlist
           node_modules/rise-common-component/scripts/deploy-gcs.sh rise-playlist $TARGET
@@ -226,23 +216,12 @@ workflows:
                 - master
                 - /^e2e[/].*/
                 - build/stable
-      - generate-version:
-          requires:
-            - preconditions
-          filters:
-            branches:
-              only:
-                - /^(stage|staging)[/].*/
-                - master
-                - /^e2e[/].*/
-                - build/stable
       - test:
           requires:
             - install
       - build:
           requires:
             - test
-            - generate-version
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description
Deploy staging to branch name

## Motivation and Context
Remove the complexity of looking up the build timestamp for staging. Consistent staging url for a branch.

## How Has This Been Tested?
Staging versions are deployed at:
https://widgets.risevision.com/staging/components/rise-playlist/stage-branch-name/rise-playlist.js

e2e tests pass.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No