### PR TITLE
Send RiseElement play/stop event names

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -85,12 +85,12 @@ export class RisePlaylistItem extends RiseElement {
 
   play() {
     this._done = false;
-    this._sendEventToChild("rise-playlist-play");
+    this._sendEventToChild(RiseElement.EVENT_RISE_PRESENTATION_PLAY);
     this._isPlaying = true;
   }
 
   stop() {
-    this._sendEventToChild("rise-playlist-stop");
+    this._sendEventToChild(RiseElement.EVENT_RISE_PRESENTATION_STOP);
     this._isPlaying = false;
   }
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -294,24 +294,24 @@
 
         suite('rise-playlist-item', () => {
 
-          test('play should send "rise-playlist-play" event to children', (done) => {
+          test('play should send "rise-presentation-play" event to children', (done) => {
             const item = new RisePlaylistItem();
             const child = document.createElement('rise-embedded-template');
             item.appendChild(child);
 
-            child.addEventListener("rise-playlist-play", () => {
+            child.addEventListener("rise-presentation-play", () => {
               done();
             });
 
             item.play();
           });
 
-          test('stop should send "rise-playlist-stop" event to children', (done) => {
+          test('stop should send "rise-presentation-stop" event to children', (done) => {
             const item = new RisePlaylistItem();
             const child = document.createElement('rise-embedded-template');
             item.appendChild(child);
 
-            child.addEventListener("rise-playlist-stop", () => {
+            child.addEventListener("rise-presentation-stop", () => {
               done();
             });
 


### PR DESCRIPTION
## Description
Send RiseElement play/stop event names

## Motivation and Context
Playlist Component epic.

## How Has This Been Tested?
RisePlayerConfiguration will no longer pass `rise-presentation-play`/`rise-presentation-stop` events to the components in a playlist. Hence, the playlist item can now pass events with the same name.

Tested changes locally with the proxy. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No