### PR TITLE
Prevent transitions from failing to complete when switching tabs

### DIFF
--- a/src/schedule.js
+++ b/src/schedule.js
@@ -28,7 +28,7 @@ class DefaultTransition {
 
   animate(from, to) {
     to.style.visibility = "hidden";
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       to.style.transition = `visibility ${this.durationInSeconds}s`;
       to.style.visibility = "visible";
     });
@@ -50,7 +50,7 @@ class FadeInTransition extends DefaultTransition {
   animate(from, to) {
     to.style.visibility = "visible";
     to.style.opacity = 0;
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       to.style.transition = `opacity ${this.durationInSeconds}s`;
       to.style.opacity = 1;
     });
@@ -61,7 +61,7 @@ class ZoomInTransition extends DefaultTransition {
   animate(from, to) {
     to.style.visibility = "visible";
     to.style.transform = "scale(0)";
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       to.style.transition = `transform ${this.durationInSeconds}s`;
       to.style.transform = "scale(1)";
     });
@@ -79,7 +79,7 @@ class HorizontalSlideTransition extends DefaultTransition {
   animate(from, to) {
     if (from) {
       from.style.left = "0px";
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         from.style.transition = `left ${this.durationInSeconds}s`;
         from.style.left = `${this.fromMultiplier * from.parentElement.clientWidth}px`;
       });
@@ -87,7 +87,7 @@ class HorizontalSlideTransition extends DefaultTransition {
 
     to.style.visibility = "visible";
     to.style.left = `${this.toMultiplier * to.parentElement.clientWidth}px`;
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       to.style.transition = `left ${this.durationInSeconds}s`;
       to.style.left = "0px";
     });
@@ -117,7 +117,7 @@ class VerticalSlideTransition extends DefaultTransition {
   animate(from, to) {
     if (from) {
       from.style.top = "0px";
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         from.style.transition = `top ${this.durationInSeconds}s`;
         from.style.top = `${this.fromMultiplier * from.parentElement.clientHeight}px`;
       });
@@ -125,7 +125,7 @@ class VerticalSlideTransition extends DefaultTransition {
 
     to.style.visibility = "visible";
     to.style.top = `${this.toMultiplier * to.parentElement.clientHeight}px`;
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       to.style.transition = `top ${this.durationInSeconds}s`;
       to.style.top = "0px";
     });


### PR DESCRIPTION
## Description
Use setTimeout() instead of requestAnimationFrame() to change property and animate on next rendering cycle.

## Motivation and Context
Playlist Component epic.
Transitions didn't work when switching tabs, causing multiple elements to be visible.
From [MDN](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame): 
"requestAnimationFrame() calls are paused in most browsers when running in background tabs or hidden <iframe>s in order to improve performance and battery life."

Note: Stripes transitions worked as expected and didn't need changes.

## How Has This Been Tested?
Tested locally with Charles proxy on multiple scenarios.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
