### PR TITLE
Skip unsupported Shared Schedule components (i.e. rise-video)

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -51,6 +51,12 @@ export class RisePlaylistItem extends RiseElement {
   ready() {
     super.ready();
     if (this.firstElementChild) {
+      // Skip unsupported Shared Schedule components (i.e. rise-video)
+      if (RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isSharedSchedule()
+          && this.firstElementChild.tagName.toLowerCase() === "rise-video") {
+        this._isError = true;
+        return;
+      }
       if (this.playUntilDone) {
         this.firstElementChild.addEventListener("report-done", () => this._setDone());
       }

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -17,6 +17,7 @@
       RisePlayerConfiguration = {
         isPreview: () => false,
         Helpers: {
+          isSharedSchedule: () => {},
           getComponentAsync: () => {},
           sendStartEvent: () => {},
           isInViewer: () => false          
@@ -82,6 +83,10 @@
 
       suite('rise-playlist', () => {
         const sandbox = sinon.createSandbox();
+
+        setup(() => {
+          sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
+        });
 
         teardown(() => sandbox.restore());
 
@@ -383,6 +388,30 @@
             child.dispatchEvent(new Event('rise-components-ready'));
 
             assert.equal(item.isNotReady(), false);
+          });
+
+          test('should skip unsupported components for Shared Schedules"', () => {
+            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
+
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-video');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.isTrue(item.isError());
+          });
+
+          test('should handle allowed components for Shared Schedules"', () => {
+            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
+
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-image');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.isFalse(item.isError());
           });
 
         });


### PR DESCRIPTION
## Description
Skip unsupported Shared Schedule components (i.e. rise-video)

## Motivation and Context
Playlist Component epic
Videos should not play in Shared Schedules, as caching is not available yet.
They will continue to show as placeholder when running locally and in the Editor.

## How Has This Been Tested?
Tested locally with both inline and JSON/items attribute based components.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
