### PR TITLE
Log an error when all items return errors or time out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-playlist",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-playlist",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Web component for displaying a playlist on a Rise Vision Template page",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -181,6 +181,7 @@ export default class RisePlaylist extends RiseElement {
     this._isPlaying = false;
     this.schedule = new Schedule();
     this.schedule.doneListener = () => this._onScheduleDone();
+    this.schedule.logEvent = (...args) => this._logEvent(...args);
     this._setVersion( version );
   }
 
@@ -268,6 +269,10 @@ export default class RisePlaylist extends RiseElement {
     }).forEach(element => {
       this.appendChild(element);
     });
+  }
+
+  _logEvent(type, event, details = null, additionalFields) {
+    super.log(type, event, details, additionalFields);
   }
 
   connectedCallback() {

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -292,7 +292,7 @@ class Schedule {
       // and all embedded templates have unsupported components like Video or Financial
       console.log("All templates faild to load");
       if (this.logEvent) {
-        this.logEvent("error", "All templates faild to load", { errorCode: "E000000108" }, {});
+        this.logEvent("error", "All templates faild to load", { errorCode: "E000000211" }, {});
       }
       setTimeout(() => this._sendDoneEvent(), 1000);
       return;
@@ -304,7 +304,7 @@ class Schedule {
     if (allTemplatesNotReady && (new Date().getTime() - this.startTime.getTime()) > PLAYLIST_LOAD_TIMEOUT_MS) {
       console.log("Playlist timed out");
       if (this.logEvent) {
-        this.logEvent("error", "Playlist timed out", { errorCode: "E000000108" }, {});
+        this.logEvent("error", "Playlist timed out", { errorCode: "E000000211" }, {});
       }
       this._sendDoneEvent();
       return;

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -241,6 +241,7 @@ class TransitionHandler {
 class Schedule {
   constructor(transitionHandler = new TransitionHandler(), doneListener = () => {}) {
     this.transitionHandler = transitionHandler;
+    this.logEvent = null;
     this.doneListener = doneListener;
     this.doneIsCalled = false;
     this.items = [];
@@ -290,6 +291,9 @@ class Schedule {
       // this condition occurs when Viewer runs without Player in the Shared Schedules mode
       // and all embedded templates have unsupported components like Video or Financial
       console.log("All templates faild to load");
+      if (this.logEvent) {
+        this.logEvent("error", "All templates faild to load", { errorCode: "E000000108" }, {});
+      }
       setTimeout(() => this._sendDoneEvent(), 1000);
       return;
     }
@@ -299,6 +303,9 @@ class Schedule {
 
     if (allTemplatesNotReady && (new Date().getTime() - this.startTime.getTime()) > PLAYLIST_LOAD_TIMEOUT_MS) {
       console.log("Playlist timed out");
+      if (this.logEvent) {
+        this.logEvent("error", "Playlist timed out", { errorCode: "E000000108" }, {});
+      }
       this._sendDoneEvent();
       return;
     }

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -298,6 +298,7 @@
           schedule.items = [firstItem, secondItem];
 
           schedule.doneListener = sandbox.spy();
+          schedule.logEvent = sandbox.spy();
 
           schedule.start();
 
@@ -308,6 +309,9 @@
           clock.tick(2000);
 
           assert.equal(schedule.doneListener.called, true, 'done is called');
+          assert.equal(schedule.logEvent.called, true, 'logEvent is called');
+          assert.equal(schedule.logEvent.getCall(0).args[1], "Playlist timed out");
+          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000108");
         });
 
         test('should call done listener if all templates return error', () => {
@@ -329,6 +333,7 @@
           schedule.items = [firstItem, secondItem];
 
           schedule.doneListener = sandbox.spy();
+          schedule.logEvent = sandbox.spy();
 
           schedule.start();
 
@@ -336,6 +341,9 @@
           clock.tick(2000);
 
           assert.equal(schedule.doneListener.called, true, 'done is called');
+          assert.equal(schedule.logEvent.called, true, 'logEvent is called');
+          assert.equal(schedule.logEvent.getCall(0).args[1], "All templates faild to load");
+          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000108");
         });
 
         test('should stop rise-playlist-item elements when playlist stops', () => {

--- a/test/schedule-test.html
+++ b/test/schedule-test.html
@@ -311,7 +311,7 @@
           assert.equal(schedule.doneListener.called, true, 'done is called');
           assert.equal(schedule.logEvent.called, true, 'logEvent is called');
           assert.equal(schedule.logEvent.getCall(0).args[1], "Playlist timed out");
-          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000108");
+          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000211");
         });
 
         test('should call done listener if all templates return error', () => {
@@ -343,7 +343,7 @@
           assert.equal(schedule.doneListener.called, true, 'done is called');
           assert.equal(schedule.logEvent.called, true, 'logEvent is called');
           assert.equal(schedule.logEvent.getCall(0).args[1], "All templates faild to load");
-          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000108");
+          assert.equal(schedule.logEvent.getCall(0).args[2].errorCode, "E000000211");
         });
 
         test('should stop rise-playlist-item elements when playlist stops', () => {


### PR DESCRIPTION
## Description
- Log errors as discussed [here](https://trello.com/c/R4YelOXd/8034-uptime-error-review-playlist-component-1) and defined in the [Uptime Standards](https://docs.google.com/document/d/1fiLb4VjARw18tSweV13rOCBcFZNruV2GR4KsabQ47ww/edit#bookmark=id.eoonlddkmbm6).

## Motivation and Context
[Uptime Standards](https://docs.google.com/document/d/1fiLb4VjARw18tSweV13rOCBcFZNruV2GR4KsabQ47ww/edit#bookmark=id.w4gnafd2zq1p).

## How Has This Been Tested?
- Unit tests
- Tested on local machine using Charles proxy
- Confined error "E000000108" is logged into BQ

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
