### PR TITLE
Render non-editable playlists in the editor

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -149,7 +149,7 @@ export default class RisePlaylist extends RiseElement {
           font-family: Helvetica, Arial, sans-serif;
         }
       </style>
-      <template is="dom-if" if="{{isInEditor()}}">
+      <template is="dom-if" if="{{shouldNotRender()}}">
       <div id="previewPlaceholder">
         <svg viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
           <g id="1.-Atoms" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
@@ -185,8 +185,9 @@ export default class RisePlaylist extends RiseElement {
     this._setVersion( version );
   }
 
-  isInEditor() {
-    return RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isEditorPreview();
+  shouldNotRender() {
+    return RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isEditorPreview() &&
+      !this.hasAttribute( "non-editable" );
   }
 
   _handleRisePresentationPlay() {
@@ -202,7 +203,7 @@ export default class RisePlaylist extends RiseElement {
   }
 
   _startSchedule() {
-    if (!this.isInEditor()) {
+    if (!this.shouldNotRender()) {
       this._isPlaying = true;
       this.schedule.start();
     }

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -197,6 +197,16 @@
             assert.equal(element.schedule.start.called, false);
           });
 
+          test('should start schedule on "rise-presentation-play" event in editor preview if non-editable', () => {
+            element.setAttribute("non-editable", true);
+            sandbox.stub(RisePlayerConfiguration.Helpers, "isEditorPreview").returns(true);
+            sandbox.stub(element.schedule, "start");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element.schedule.start.called, true);
+          });
+
           test('should stop schedule on "rise-presentation-stop" event', () => {
             sandbox.stub(element.schedule, "stop");
 


### PR DESCRIPTION
## Description
Render non-editable playlists in the editor

Allow designer created playlists to be rendered

## Motivation and Context
Playlist Component epic

## How Has This Been Tested?
Tested locally via the proxy. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No