### PR TITLE
Set play-until-done and element properties via Polymer method

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -51,6 +51,12 @@ export class RisePlaylistItem extends RiseElement {
   ready() {
     super.ready();
     if (this.firstElementChild) {
+      // Skip unsupported Shared Schedule components (i.e. rise-video)
+      if (RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isSharedSchedule()
+          && this.firstElementChild.tagName.toLowerCase() === "rise-video") {
+        this._isError = true;
+        return;
+      }
       if (this.playUntilDone) {
         this.firstElementChild.addEventListener("report-done", () => this._setDone());
       }

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -254,6 +254,10 @@ export default class RisePlaylist extends RiseElement {
 
       element.setAttribute("id", playListItemId + "_" + item.element.tagName);
 
+      if (item["play-until-done"]) {
+        element.setAttribute("play-until-done", item["play-until-done"]);
+      }
+
       Object.entries(item.element.attributes).forEach(([key, value]) => {
         element.setAttribute(key, value);
       });

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -51,12 +51,6 @@ export class RisePlaylistItem extends RiseElement {
   ready() {
     super.ready();
     if (this.firstElementChild) {
-      // Skip unsupported Shared Schedule components (i.e. rise-video)
-      if (RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isSharedSchedule()
-          && this.firstElementChild.tagName.toLowerCase() === "rise-video") {
-        this._isError = true;
-        return;
-      }
       if (this.playUntilDone) {
         this.firstElementChild.addEventListener("report-done", () => this._setDone());
       }

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -57,8 +57,6 @@ export class RisePlaylistItem extends RiseElement {
 
       this.firstElementChild.addEventListener("rise-components-ready", () => this._setReady());
       this.firstElementChild.addEventListener("rise-components-error", () => this._isError = true);
-
-      RisePlayerConfiguration.Helpers.sendStartEvent( this.firstElementChild );
     }
   }
 
@@ -220,6 +218,22 @@ export default class RisePlaylist extends RiseElement {
     }
   }
 
+  _convertHyphensToCamelCase (string) {
+    return string.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+  }
+
+  _setPropertiesNative( element, attributes ) {
+    const updatedAttributes = {};
+
+    Object.entries(attributes).forEach(([key, value]) => {
+      updatedAttributes[this._convertHyphensToCamelCase(key)] = value;
+    });
+
+    console.log(`Setting attributes component=${element.tagName.toLowerCase()}, id=${element.id} to value`, updatedAttributes);
+
+    element.setProperties(updatedAttributes);
+  }
+
   _itemsChanged(items) {
     this._removeAllItems();
 
@@ -258,9 +272,9 @@ export default class RisePlaylist extends RiseElement {
         element.setAttribute("play-until-done", item["play-until-done"]);
       }
 
-      Object.entries(item.element.attributes).forEach(([key, value]) => {
-        element.setAttribute(key, value);
-      });
+      RisePlayerConfiguration.Helpers.getComponentAsync( element )
+        .then( this._setPropertiesNative.bind( this, element, item.element.attributes ))
+        .then( RisePlayerConfiguration.Helpers.sendStartEvent.bind( null, element ));
 
       playListItem.appendChild(element);
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -16,7 +16,6 @@
     <script type="text/javascript">
       RisePlayerConfiguration = {
         Helpers: {
-          isSharedSchedule: () => {},
           getComponentAsync: () => {},
           sendStartEvent: () => {},
           isEditorPreview: () => false          
@@ -82,10 +81,6 @@
 
       suite('rise-playlist', () => {
         const sandbox = sinon.createSandbox();
-
-        setup(() => {
-          sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
-        });
 
         teardown(() => sandbox.restore());
 
@@ -386,30 +381,6 @@
             child.dispatchEvent(new Event('rise-components-ready'));
 
             assert.equal(item.isNotReady(), false);
-          });
-
-          test('should skip unsupported components for Shared Schedules"', () => {
-            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
-
-            const item = new RisePlaylistItem();
-            const child = document.createElement('rise-video');
-            item.appendChild(child);
-
-            item.ready();
-
-            assert.isTrue(item.isError());
-          });
-
-          test('should handle allowed components for Shared Schedules"', () => {
-            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
-
-            const item = new RisePlaylistItem();
-            const child = document.createElement('rise-image');
-            item.appendChild(child);
-
-            item.ready();
-
-            assert.isFalse(item.isError());
           });
 
         });

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -38,6 +38,19 @@
               "template-id": "a429c126-598d-4251-9c0e-b49821056608"
             }
           }
+        },
+        {
+          "duration": 3,
+          "transition-type": "fadeIn",
+          "play-until-done": true,
+          "element": {
+            "tagName": "rise-image",
+            "attributes": {
+              "metadata": {
+                "fileName": "sample-image.png"
+              }
+            }
+          }
         }]'>
         </rise-playlist>
       </template>
@@ -93,8 +106,8 @@
 
           test('setting "items" attribute on the element works', (done) => {
             flush(() => {
-              assert.equal(element.items.length, 1);
-              assert.equal(element.schedule.items.length, 1);
+              assert.equal(element.items.length, 2);
+              assert.equal(element.schedule.items.length, 2);
               done();
             });
           });
@@ -171,6 +184,32 @@
               assert.equal(playlistItemElements[1].id, "playlist1_2");
               let embeddedTemplateElement = playlistItemElements[0].firstChild;
               assert.equal(embeddedTemplateElement.id, "playlist1_1_rise-embedded-template");
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+              assert.isFalse(playlistItemElements[0].playUntilDone);
+              assert.isTrue(playlistItemElements[1].playUntilDone);
+
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute for the component', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+              assert.isNull(embeddedTemplateElement.getAttribute('play-until-done'));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.equal(imageElement.getAttribute('play-until-done'), 'true');
+
               done();
             });
           });

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -16,6 +16,7 @@
     <script type="text/javascript">
       RisePlayerConfiguration = {
         Helpers: {
+          isSharedSchedule: () => {},
           getComponentAsync: () => {},
           sendStartEvent: () => {},
           isEditorPreview: () => false          
@@ -98,6 +99,7 @@
         setup(() => {
           sandbox.stub(RisePlayerConfiguration.Helpers, 'getComponentAsync').resolves();
           sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
+          sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
         });
 
         teardown(() => sandbox.restore());
@@ -453,6 +455,30 @@
             child.dispatchEvent(new Event('rise-components-ready'));
 
             assert.equal(item.isNotReady(), false);
+          });
+
+          test('should skip unsupported components for Shared Schedules"', () => {
+            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
+
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-video');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.isTrue(item.isError());
+          });
+
+          test('should handle allowed components for Shared Schedules"', () => {
+            RisePlayerConfiguration.Helpers.isSharedSchedule.returns(true);
+
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-image');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.isFalse(item.isError());
           });
 
         });

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -95,6 +95,11 @@
       suite('rise-playlist', () => {
         const sandbox = sinon.createSandbox();
 
+        setup(() => {
+          sandbox.stub(RisePlayerConfiguration.Helpers, 'getComponentAsync').resolves();
+          sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
+        });
+
         teardown(() => sandbox.restore());
 
         suite('static items attribute', () => {
@@ -102,6 +107,8 @@
 
           setup(() => {
             element = fixture('StaticValueTestFixture');
+
+            Element.prototype.setProperties = sandbox.stub();
           });
 
           test('setting "items" attribute on the element works', (done) => {
@@ -209,6 +216,44 @@
 
               let imageElement = playlistItemElements[1].firstChild;
               assert.equal(imageElement.getAttribute('play-until-done'), 'true');
+
+              done();
+            });
+          });
+
+          test('setting properties for the component', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+
+              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(embeddedTemplateElement));
+              assert.isTrue(embeddedTemplateElement.setProperties.called);
+              assert.isTrue(embeddedTemplateElement.setProperties.calledWith({
+                templateId: "a429c126-598d-4251-9c0e-b49821056608"
+              }));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(imageElement));
+              assert.isTrue(imageElement.setProperties.called);
+              assert.isTrue(imageElement.setProperties.calledWith({
+                metadata: {
+                  fileName: "sample-image.png"
+                }
+              }));
+
+              done();
+            });
+          });
+
+          test('should send start event', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+
+              assert.isTrue(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(embeddedTemplateElement));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.isTrue(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(imageElement));
 
               done();
             });
@@ -354,18 +399,6 @@
             });
 
             item.stop();
-          });
-
-          test('stop should "start" event to children', () => {
-            sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
-
-            const item = new RisePlaylistItem();
-            const child = document.createElement('rise-embedded-template');
-            item.appendChild(child);
-
-            item.ready();
-
-            assert.equal(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(child), true);
           });
 
           test('should set done when child sends "report-done"', () => {


### PR DESCRIPTION
## Description
Set the play-until-done attribute on the element (#51)
components require the attribute to know
if they should send done or not

Set element properties via polymer method (#52)
Allows object type properties to be set correctly
Convert property names to camel case

Send start event after properties are updated

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested locally with the proxy. Updated coverage.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No