### PR TITLE
Set the play-until-done attribute on the element

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -260,6 +260,10 @@ export default class RisePlaylist extends RiseElement {
 
       element.setAttribute("id", playListItemId + "_" + item.element.tagName);
 
+      if (item["play-until-done"]) {
+        element.setAttribute("play-until-done", item["play-until-done"]);
+      }
+
       Object.entries(item.element.attributes).forEach(([key, value]) => {
         element.setAttribute(key, value);
       });

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -39,6 +39,19 @@
               "template-id": "a429c126-598d-4251-9c0e-b49821056608"
             }
           }
+        },
+        {
+          "duration": 3,
+          "transition-type": "fadeIn",
+          "play-until-done": true,
+          "element": {
+            "tagName": "rise-image",
+            "attributes": {
+              "metadata": {
+                "fileName": "sample-image.png"
+              }
+            }
+          }
         }]'>
         </rise-playlist>
       </template>
@@ -98,8 +111,8 @@
 
           test('setting "items" attribute on the element works', (done) => {
             flush(() => {
-              assert.equal(element.items.length, 1);
-              assert.equal(element.schedule.items.length, 1);
+              assert.equal(element.items.length, 2);
+              assert.equal(element.schedule.items.length, 2);
               done();
             });
           });
@@ -176,6 +189,32 @@
               assert.equal(playlistItemElements[1].id, "playlist1_2");
               let embeddedTemplateElement = playlistItemElements[0].firstChild;
               assert.equal(embeddedTemplateElement.id, "playlist1_1_rise-embedded-template");
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+              assert.isFalse(playlistItemElements[0].playUntilDone);
+              assert.isTrue(playlistItemElements[1].playUntilDone);
+
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute for the component', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+              assert.isNull(embeddedTemplateElement.getAttribute('play-until-done'));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.equal(imageElement.getAttribute('play-until-done'), 'true');
+
               done();
             });
           });


### PR DESCRIPTION
## Description
Set the play-until-done attribute on the element

components require the attribute to know
if they should send done or not

## Motivation and Context
Playlist UI

## How Has This Been Tested?
Tested changes locally with various components. Updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No