### PR TITLE
Revert "Set play-until-done and element properties via Polymer method (#50)"

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -63,6 +63,8 @@ export class RisePlaylistItem extends RiseElement {
 
       this.firstElementChild.addEventListener("rise-components-ready", () => this._setReady());
       this.firstElementChild.addEventListener("rise-components-error", () => this._isError = true);
+
+      RisePlayerConfiguration.Helpers.sendStartEvent( this.firstElementChild );
     }
   }
 
@@ -224,22 +226,6 @@ export default class RisePlaylist extends RiseElement {
     }
   }
 
-  _convertHyphensToCamelCase (string) {
-    return string.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
-  }
-
-  _setPropertiesNative( element, attributes ) {
-    const updatedAttributes = {};
-
-    Object.entries(attributes).forEach(([key, value]) => {
-      updatedAttributes[this._convertHyphensToCamelCase(key)] = value;
-    });
-
-    console.log(`Setting attributes component=${element.tagName.toLowerCase()}, id=${element.id} to value`, updatedAttributes);
-
-    element.setProperties(updatedAttributes);
-  }
-
   _itemsChanged(items) {
     this._removeAllItems();
 
@@ -274,13 +260,9 @@ export default class RisePlaylist extends RiseElement {
 
       element.setAttribute("id", playListItemId + "_" + item.element.tagName);
 
-      if (item["play-until-done"]) {
-        element.setAttribute("play-until-done", item["play-until-done"]);
-      }
-
-      RisePlayerConfiguration.Helpers.getComponentAsync( element )
-        .then( this._setPropertiesNative.bind( this, element, item.element.attributes ))
-        .then( RisePlayerConfiguration.Helpers.sendStartEvent.bind( null, element ));
+      Object.entries(item.element.attributes).forEach(([key, value]) => {
+        element.setAttribute(key, value);
+      });
 
       playListItem.appendChild(element);
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -39,19 +39,6 @@
               "template-id": "a429c126-598d-4251-9c0e-b49821056608"
             }
           }
-        },
-        {
-          "duration": 3,
-          "transition-type": "fadeIn",
-          "play-until-done": true,
-          "element": {
-            "tagName": "rise-image",
-            "attributes": {
-              "metadata": {
-                "fileName": "sample-image.png"
-              }
-            }
-          }
         }]'>
         </rise-playlist>
       </template>
@@ -97,8 +84,6 @@
         const sandbox = sinon.createSandbox();
 
         setup(() => {
-          sandbox.stub(RisePlayerConfiguration.Helpers, 'getComponentAsync').resolves();
-          sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
           sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
         });
 
@@ -109,14 +94,12 @@
 
           setup(() => {
             element = fixture('StaticValueTestFixture');
-
-            Element.prototype.setProperties = sandbox.stub();
           });
 
           test('setting "items" attribute on the element works', (done) => {
             flush(() => {
-              assert.equal(element.items.length, 2);
-              assert.equal(element.schedule.items.length, 2);
+              assert.equal(element.items.length, 1);
+              assert.equal(element.schedule.items.length, 1);
               done();
             });
           });
@@ -193,70 +176,6 @@
               assert.equal(playlistItemElements[1].id, "playlist1_2");
               let embeddedTemplateElement = playlistItemElements[0].firstChild;
               assert.equal(embeddedTemplateElement.id, "playlist1_1_rise-embedded-template");
-              done();
-            });
-          });
-
-          test('setting play-until-done attribute', (done) => {
-            flush(() => {
-              let playlistItemElements = element.children;
-              assert.equal(playlistItemElements.length, 2);
-              assert.isFalse(playlistItemElements[0].playUntilDone);
-              assert.isTrue(playlistItemElements[1].playUntilDone);
-
-              done();
-            });
-          });
-
-          test('setting play-until-done attribute for the component', (done) => {
-            flush(() => {
-              let playlistItemElements = element.children;
-              assert.equal(playlistItemElements.length, 2);
-
-              let embeddedTemplateElement = playlistItemElements[0].firstChild;
-              assert.isNull(embeddedTemplateElement.getAttribute('play-until-done'));
-
-              let imageElement = playlistItemElements[1].firstChild;
-              assert.equal(imageElement.getAttribute('play-until-done'), 'true');
-
-              done();
-            });
-          });
-
-          test('setting properties for the component', (done) => {
-            flush(() => {
-              let playlistItemElements = element.children;
-              let embeddedTemplateElement = playlistItemElements[0].firstChild;
-
-              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(embeddedTemplateElement));
-              assert.isTrue(embeddedTemplateElement.setProperties.called);
-              assert.isTrue(embeddedTemplateElement.setProperties.calledWith({
-                templateId: "a429c126-598d-4251-9c0e-b49821056608"
-              }));
-
-              let imageElement = playlistItemElements[1].firstChild;
-              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(imageElement));
-              assert.isTrue(imageElement.setProperties.called);
-              assert.isTrue(imageElement.setProperties.calledWith({
-                metadata: {
-                  fileName: "sample-image.png"
-                }
-              }));
-
-              done();
-            });
-          });
-
-          test('should send start event', (done) => {
-            flush(() => {
-              let playlistItemElements = element.children;
-              let embeddedTemplateElement = playlistItemElements[0].firstChild;
-
-              assert.isTrue(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(embeddedTemplateElement));
-
-              let imageElement = playlistItemElements[1].firstChild;
-              assert.isTrue(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(imageElement));
-
               done();
             });
           });
@@ -401,6 +320,18 @@
             });
 
             item.stop();
+          });
+
+          test('stop should "start" event to children', () => {
+            sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
+
+            const item = new RisePlaylistItem();
+            const child = document.createElement('rise-embedded-template');
+            item.appendChild(child);
+
+            item.ready();
+
+            assert.equal(RisePlayerConfiguration.Helpers.sendStartEvent.calledWith(child), true);
           });
 
           test('should set done when child sends "report-done"', () => {


### PR DESCRIPTION
## Description
Revert "Set play-until-done and element properties via Polymer method (#50)"

This reverts commit 58683b4b0fbde06ad25531587790a18ebdc58cfb.

## Motivation and Context
Fix for #55 

## How Has This Been Tested?
Revert to a previous commit.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No