### PR TITLE
Set element play-until-done and properties via Polymer

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -226,6 +226,22 @@ export default class RisePlaylist extends RiseElement {
     }
   }
 
+  _convertHyphensToCamelCase (string) {
+    return string.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+  }
+
+  _setPropertiesNative( element, attributes ) {
+    const updatedAttributes = {};
+
+    Object.entries(attributes).forEach(([key, value]) => {
+      updatedAttributes[this._convertHyphensToCamelCase(key)] = value;
+    });
+
+    console.log(`Setting attributes component=${element.tagName.toLowerCase()}, id=${element.id} to value`, updatedAttributes);
+
+    element.setProperties(updatedAttributes);
+  }
+
   _itemsChanged(items) {
     this._removeAllItems();
 
@@ -260,9 +276,12 @@ export default class RisePlaylist extends RiseElement {
 
       element.setAttribute("id", playListItemId + "_" + item.element.tagName);
 
-      Object.entries(item.element.attributes).forEach(([key, value]) => {
-        element.setAttribute(key, value);
-      });
+      if (item["play-until-done"]) {
+        element.setAttribute("play-until-done", item["play-until-done"]);
+      }
+
+      RisePlayerConfiguration.Helpers.getComponentAsync( element )
+        .then( this._setPropertiesNative.bind( this, element, item.element.attributes ));
 
       playListItem.appendChild(element);
 

--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -280,8 +280,7 @@ export default class RisePlaylist extends RiseElement {
         element.setAttribute("play-until-done", item["play-until-done"]);
       }
 
-      RisePlayerConfiguration.Helpers.getComponentAsync( element )
-        .then( this._setPropertiesNative.bind( this, element, item.element.attributes ));
+      this._setPropertiesNative( element, item.element.attributes );
 
       playListItem.appendChild(element);
 

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -39,6 +39,19 @@
               "template-id": "a429c126-598d-4251-9c0e-b49821056608"
             }
           }
+        },
+        {
+          "duration": 3,
+          "transition-type": "fadeIn",
+          "play-until-done": true,
+          "element": {
+            "tagName": "rise-image",
+            "attributes": {
+              "metadata": {
+                "fileName": "sample-image.png"
+              }
+            }
+          }
         }]'>
         </rise-playlist>
       </template>
@@ -84,6 +97,8 @@
         const sandbox = sinon.createSandbox();
 
         setup(() => {
+          sandbox.stub(RisePlayerConfiguration.Helpers, 'getComponentAsync').resolves();
+          sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
           sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
         });
 
@@ -94,12 +109,14 @@
 
           setup(() => {
             element = fixture('StaticValueTestFixture');
+
+            Element.prototype.setProperties = sandbox.stub();
           });
 
           test('setting "items" attribute on the element works', (done) => {
             flush(() => {
-              assert.equal(element.items.length, 1);
-              assert.equal(element.schedule.items.length, 1);
+              assert.equal(element.items.length, 2);
+              assert.equal(element.schedule.items.length, 2);
               done();
             });
           });
@@ -176,6 +193,56 @@
               assert.equal(playlistItemElements[1].id, "playlist1_2");
               let embeddedTemplateElement = playlistItemElements[0].firstChild;
               assert.equal(embeddedTemplateElement.id, "playlist1_1_rise-embedded-template");
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+              assert.isFalse(playlistItemElements[0].playUntilDone);
+              assert.isTrue(playlistItemElements[1].playUntilDone);
+
+              done();
+            });
+          });
+
+          test('setting play-until-done attribute for the component', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              assert.equal(playlistItemElements.length, 2);
+
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+              assert.isNull(embeddedTemplateElement.getAttribute('play-until-done'));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.equal(imageElement.getAttribute('play-until-done'), 'true');
+
+              done();
+            });
+          });
+
+          test('setting properties for the component', (done) => {
+            flush(() => {
+              let playlistItemElements = element.children;
+              let embeddedTemplateElement = playlistItemElements[0].firstChild;
+
+              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(embeddedTemplateElement));
+              assert.isTrue(embeddedTemplateElement.setProperties.called);
+              assert.isTrue(embeddedTemplateElement.setProperties.calledWith({
+                templateId: "a429c126-598d-4251-9c0e-b49821056608"
+              }));
+
+              let imageElement = playlistItemElements[1].firstChild;
+              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(imageElement));
+              assert.isTrue(imageElement.setProperties.called);
+              assert.isTrue(imageElement.setProperties.calledWith({
+                metadata: {
+                  fileName: "sample-image.png"
+                }
+              }));
+
               done();
             });
           });
@@ -323,8 +390,6 @@
           });
 
           test('stop should "start" event to children', () => {
-            sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
-
             const item = new RisePlaylistItem();
             const child = document.createElement('rise-embedded-template');
             item.appendChild(child);

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -17,10 +17,13 @@
       RisePlayerConfiguration = {
         Helpers: {
           isSharedSchedule: () => {},
+          getComponentAsync: () => {},
           sendStartEvent: () => {},
           isEditorPreview: () => false          
         }
       };
+
+      Element.prototype.setProperties = () => {};
     </script>
 
     <script type="module" src="../src/rise-playlist.js"></script>
@@ -106,9 +109,9 @@
           let element = null;
 
           setup(() => {
-            element = fixture('StaticValueTestFixture');
+            sandbox.spy(Element.prototype, 'setProperties');
 
-            Element.prototype.setProperties = sandbox.stub();
+            element = fixture('StaticValueTestFixture');
           });
 
           test('setting "items" attribute on the element works', (done) => {

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -17,7 +17,6 @@
       RisePlayerConfiguration = {
         Helpers: {
           isSharedSchedule: () => {},
-          getComponentAsync: () => {},
           sendStartEvent: () => {},
           isEditorPreview: () => false          
         }
@@ -97,7 +96,6 @@
         const sandbox = sinon.createSandbox();
 
         setup(() => {
-          sandbox.stub(RisePlayerConfiguration.Helpers, 'getComponentAsync').resolves();
           sandbox.stub(RisePlayerConfiguration.Helpers, 'sendStartEvent');
           sandbox.stub(RisePlayerConfiguration.Helpers, "isSharedSchedule").returns(false);
         });
@@ -228,14 +226,12 @@
               let playlistItemElements = element.children;
               let embeddedTemplateElement = playlistItemElements[0].firstChild;
 
-              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(embeddedTemplateElement));
               assert.isTrue(embeddedTemplateElement.setProperties.called);
               assert.isTrue(embeddedTemplateElement.setProperties.calledWith({
                 templateId: "a429c126-598d-4251-9c0e-b49821056608"
               }));
 
               let imageElement = playlistItemElements[1].firstChild;
-              assert.isTrue(RisePlayerConfiguration.Helpers.getComponentAsync.calledWith(imageElement));
               assert.isTrue(imageElement.setProperties.called);
               assert.isTrue(imageElement.setProperties.calledWith({
                 metadata: {


### PR DESCRIPTION
## Description
Set element play-until-done and properties via Polymer

Set the play-until-done attribute on the element (#51)
components require the attribute to know
if they should send done or not

Set element properties via polymer method (#52)
Allows object type properties to be set correctly
Convert property names to camel case

## Motivation and Context
Re-release #50 without the change that introduced #55 

## How Has This Been Tested?
Tested with the proxy and updated unit tests.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No