### PR TITLE
Update readme to reference the allowed-components parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,12 @@ This component receives the following list of attributes:
 - **items**: ( string / optional ): Playlist items.
 - **label**: ( string / optional ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the template editor.
-
+- **allowed-components**: ( csv string / optional ): An optional CSV separated list of components that are available for selection in Apps. 
+    The following conditions apply:
+    - If the template is not using rise-init, the parameter is ignored and we only allow selecting Presentations.
+    - If the template is using rise-init, and the parameter is missing, blank, or *, we show all the components available.
+    - If the parameter contains a comma separate list of components, say `"rise-embedded-template,rise-video,rise-slides"` we only allow
+    selection of those 3 components.
 
 ### Events
 


### PR DESCRIPTION
## Description
Update readme to reference the allowed-components parameter

This parameter is used for Apps only, not within the component itself

## Motivation and Context
Playlist UI.

## How Has This Been Tested?
Documentation update. No changes to functionality.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No