### PR TITLE
Fix placeholder not being rendered on initial presentation load

### DIFF
--- a/src/rise-playlist.js
+++ b/src/rise-playlist.js
@@ -174,6 +174,7 @@ export default class RisePlaylist extends RiseElement {
     return {
       items: {
         type: Array,
+        value: null, // initialize as 'null' to trigger placeholder rendering check, as 'undefined' value does not trigger observers
         observer: "_itemsChanged"
       }
     }
@@ -190,7 +191,7 @@ export default class RisePlaylist extends RiseElement {
 
   _shouldNotRender(items) {
     return RisePlayerConfiguration && RisePlayerConfiguration.Helpers.isEditorPreview() &&
-      (!items || items.length === 0);
+      !this.hasAttribute( "non-editable" ) && (!items || items.length === 0);
   }
 
   _handleRisePresentationPlay() {
@@ -246,6 +247,11 @@ export default class RisePlaylist extends RiseElement {
   }
 
   _itemsChanged(items) {
+    // ignore default null value
+    if (items === null) {
+      return;
+    }
+
     this._removeAllItems();
 
     const validItems = items.filter(item => {

--- a/test/rise-playlist-test.html
+++ b/test/rise-playlist-test.html
@@ -278,6 +278,17 @@
             assert.equal(element.schedule.start.called, false);
           });
 
+          test('should start schedule on "rise-presentation-play" event in editor preview if non-editable', () => {
+            element.setAttribute("non-editable", true);
+            element.items = [];
+            sandbox.stub(RisePlayerConfiguration.Helpers, "isEditorPreview").returns(true);
+            sandbox.stub(element.schedule, "start");
+
+            element.dispatchEvent(new Event("rise-presentation-play"));
+
+            assert.equal(element.schedule.start.called, true);
+          });
+
           test('should stop schedule on "rise-presentation-stop" event', () => {
             sandbox.stub(element.schedule, "stop");
 
@@ -312,6 +323,10 @@
 
           setup(() => {
             element = fixture('NestedElementsTestFixture');
+          });
+
+          test('"items" property is initialized as null, not undefined, to trigger placeholder check', () => {
+            assert.isTrue(element.items === null);
           });
 
           test('nested elements are parsed into schedule items', (done) => {


### PR DESCRIPTION
## Description
Fix placeholder not being rendered on initial presentation load. 

Also, skip placeholder rendering if playlist is non-editable.

## Motivation and Context
As items was initially set as `undefined`, the placeholder conditional was not being rendered. Per polymer documentation, computed function is not invoked until at least one dependency is defined (!== undefined). So we default it to null to force computed function to be invoked.



## How Has This Been Tested?
With charles proxy, on editor and player.

Stage link: widgets.risevision.com/staging/components/rise-playlist/start-editor-rendering/rise-playlist-bundle.min.js

Sample presentation: https://apps-stage-1.risevision.com/templates/edit/084855d6-641f-4b35-87de-a1a91c5ffc92/?cid=554d3ef9-78b7-4726-8f46-c1ec140c166d
Non editable: https://apps-stage-1.risevision.com/templates/edit/d8653142-0d06-48f0-b42a-af8706ad559c/?cid=554d3ef9-78b7-4726-8f46-c1ec140c166d

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
